### PR TITLE
chore(ci): run tests on PRs and tags only, with multi-OS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: Utify CI Tests
 on:
-  push:
   pull_request:
+  push:
+    tags:
+      - 'v*'
 jobs:
   test:
     name: Run Tests on ${{ matrix.os }}
@@ -16,8 +18,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Run Tests
-        run: make test
       - name: Run Tests with Coverage
         run: make coverage
       - name: Upload Coverage Report

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,23 +1,18 @@
 run:
   timeout: 2m
   tests: true
-  skip-dirs:
-    - bin
 linters:
   enable:
-    - errcheck # Verifica se erros de funções são tratados
-    - govet # Vet padrão do Go
-    - gosimple # Simplificações possíveis
-    - staticcheck # Análise estática poderosa
-    - typecheck # Verificação de tipos
-    - unused # Variáveis ou funções não utilizadas
-    - deadcode # Código morto
-    - structcheck # Campos não utilizados
-    - varcheck # Variáveis globais não usadas
-    - revive # Substituto moderno do golint
-    - gofmt # Enforce gofmt
-    - goimports # Enforce import order
-    - depguard # Restringe imports indesejados
+    - errcheck
+    - govet
+    - gosimple
+    - staticcheck
+    - typecheck
+    - unused
+    - revive
+    - gofmt
+    - goimports
+    - depguard
 linters-settings:
   errcheck:
     check-type-assertions: true
@@ -28,8 +23,8 @@ linters-settings:
       rules = [
         { name = "indent-error-flow" },
         { name = "var-naming" },
-        { name = "imports-blacklist", arguments = ["fmt"] },
         { name = "blank-imports", severity = "error" },
+        { name = "exported", severity = "warning" }
       ]
   gofmt:
     simplify: true
@@ -44,7 +39,8 @@ issues:
   max-same-issues: 5
   max-issues-per-linter: 0
   max-issues: 0
-  exclude:
-    - "should have comment or be unexported" # ignora exigência de comentários
+  exclude-dirs:
+    - bin
 output:
-  format: colored-line-number
+  formats:
+    - format: colored-line-number

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,50 @@
+run:
+  timeout: 2m
+  tests: true
+  skip-dirs:
+    - bin
+linters:
+  enable:
+    - errcheck # Verifica se erros de funções são tratados
+    - govet # Vet padrão do Go
+    - gosimple # Simplificações possíveis
+    - staticcheck # Análise estática poderosa
+    - typecheck # Verificação de tipos
+    - unused # Variáveis ou funções não utilizadas
+    - deadcode # Código morto
+    - structcheck # Campos não utilizados
+    - varcheck # Variáveis globais não usadas
+    - revive # Substituto moderno do golint
+    - gofmt # Enforce gofmt
+    - goimports # Enforce import order
+    - depguard # Restringe imports indesejados
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+  revive:
+    config: |
+      ignoreGeneratedHeader = false
+      severity = "warning"
+      rules = [
+        { name = "indent-error-flow" },
+        { name = "var-naming" },
+        { name = "imports-blacklist", arguments = ["fmt"] },
+        { name = "blank-imports", severity = "error" },
+      ]
+  gofmt:
+    simplify: true
+  depguard:
+    list-type: blacklist
+    packages:
+      - fmt
+    packages-with-error-message:
+      fmt: "Use 'log' or structured logging instead of 'fmt' in core logic"
+issues:
+  exclude-use-default: false
+  max-same-issues: 5
+  max-issues-per-linter: 0
+  max-issues: 0
+  exclude:
+    - "should have comment or be unexported" # ignora exigência de comentários
+output:
+  format: colored-line-number

--- a/Makefile
+++ b/Makefile
@@ -1,62 +1,71 @@
-BINARY = utify
-BUILD_DIR = bin
-SRC_DIR = .
-TEST_DIR = .
-GOFLAGS = -mod=readonly
-LDFLAGS = -s -w
+BINARY     = utify
+BUILD_DIR  = bin
+SRC_DIR    = .
+TEST_DIR   = .
+GOFLAGS    = -mod=readonly
+LDFLAGS    = -s -w
 
+# OS-specific configuration
 OS := $(shell uname -s)
 
 ifeq ($(OS), Darwin)
-    SED_I = sed -i ''
+	SED_I = sed -i ''
 else
-    SED_I = sed -i
+	SED_I = sed -i
 endif
 
+# Linter setup
 LINTER = golangci-lint run
 
+# Build the binary
 build:
 	@echo "🔨 Building $(BINARY)..."
 	@mkdir -p $(BUILD_DIR)
 	@go build -o $(BUILD_DIR)/$(BINARY) -ldflags "$(LDFLAGS)" $(SRC_DIR)
 	@echo "✅ Build complete: $(BUILD_DIR)/$(BINARY)"
 
+# Build and run
 run: build
 	@echo "🚀 Running $(BINARY)..."
 	@./$(BUILD_DIR)/$(BINARY)
 
+# Run tests with verbose output
 test:
 	@echo "🧪 Running tests..."
 	@go test -v ./...
 
+# Run tests with coverage and generate report
 coverage:
-	@echo "📊 Running tests with coverage (profile: coverage.out)..."
+	@echo "📊 Running tests with coverage..."
 	@go test -coverprofile=coverage.out ./...
+	@go tool cover -func=coverage.out
 
-coverage-html: coverage
-	@echo "🌐 Opening HTML coverage report..."
-	@go tool cover -html=coverage.out
-
-lint:
-	@echo "🔍 Running linters..."
-	@$(LINTER)
-
-check: lint coverage
-	@echo "✅ All checks passed."
-
+# Clean up build and coverage files
 clean:
 	@echo "🧹 Cleaning up..."
 	@rm -rf $(BUILD_DIR) coverage.out
 	@echo "✅ Cleanup complete."
 
+# Run linters
+lint:
+	@echo "🔍 Running linters..."
+	@$(LINTER)
+
+# Validate documentation and code style
+docs:
+	@echo "📚 Validating documentation and static checks..."
+	@revive -config revive.toml ./...
+	@go vet ./...
+	@echo "✅ Docs and vet checks passed."
+
+# Display available commands
 help:
 	@echo "📌 Available commands:"
-	@echo "  make build          - Build the binary"
-	@echo "  make run            - Build and run the application"
-	@echo "  make test           - Run tests"
-	@echo "  make coverage       - Run tests with coverage (to coverage.out)"
-	@echo "  make coverage-html  - Open HTML report for coverage"
-	@echo "  make lint           - Run linters (requires golangci-lint)"
-	@echo "  make check          - Run lint and coverage (CI)"
-	@echo "  make clean          - Remove generated files"
+	@echo "  make build      - Build the binary"
+	@echo "  make run        - Build and run the application"
+	@echo "  make test       - Run tests"
+	@echo "  make coverage   - Run tests with coverage"
+	@echo "  make lint       - Run linters (requires golangci-lint)"
+	@echo "  make docs       - Run revive and go vet to validate docs"
+	@echo "  make clean      - Remove generated files"
 

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
-BINARY=utify
-BUILD_DIR=bin
-SRC_DIR=.
-TEST_DIR=.
-GOFLAGS=-mod=readonly
-LDFLAGS=-s -w
+BINARY = utify
+BUILD_DIR = bin
+SRC_DIR = .
+TEST_DIR = .
+GOFLAGS = -mod=readonly
+LDFLAGS = -s -w
 
 OS := $(shell uname -s)
 
 ifeq ($(OS), Darwin)
-    SED_I=sed -i ''
+    SED_I = sed -i ''
 else
-    SED_I=sed -i
+    SED_I = sed -i
 endif
 
-LINTER=golangci-lint run
+LINTER = golangci-lint run
 
 build:
 	@echo "🔨 Building $(BINARY)..."
@@ -30,23 +30,33 @@ test:
 	@go test -v ./...
 
 coverage:
-	@echo "📊 Running tests with coverage..."
-	@go test -cover ./... | tee coverage.out
+	@echo "📊 Running tests with coverage (profile: coverage.out)..."
+	@go test -coverprofile=coverage.out ./...
+
+coverage-html: coverage
+	@echo "🌐 Opening HTML coverage report..."
+	@go tool cover -html=coverage.out
+
+lint:
+	@echo "🔍 Running linters..."
+	@$(LINTER)
+
+check: lint coverage
+	@echo "✅ All checks passed."
 
 clean:
 	@echo "🧹 Cleaning up..."
 	@rm -rf $(BUILD_DIR) coverage.out
 	@echo "✅ Cleanup complete."
 
-lint:
-	@echo "🔍 Running linters..."
-	@$(LINTER)
-
 help:
 	@echo "📌 Available commands:"
-	@echo "  make build      - Build the binary"
-	@echo "  make run        - Build and run the application"
-	@echo "  make test       - Run tests"
-	@echo "  make coverage   - Run tests with coverage"
-	@echo "  make lint       - Run linters (requires golangci-lint)"
-	@echo "  make clean      - Remove generated files"
+	@echo "  make build          - Build the binary"
+	@echo "  make run            - Build and run the application"
+	@echo "  make test           - Run tests"
+	@echo "  make coverage       - Run tests with coverage (to coverage.out)"
+	@echo "  make coverage-html  - Open HTML report for coverage"
+	@echo "  make lint           - Run linters (requires golangci-lint)"
+	@echo "  make check          - Run lint and coverage (CI)"
+	@echo "  make clean          - Remove generated files"
+

--- a/revive.toml
+++ b/revive.toml
@@ -1,0 +1,30 @@
+[ignore]
+# Optional: exclude testdata or vendor
+# paths = ["vendor", "testdata"]
+
+# Set output style
+[output]
+format = "friendly"
+
+# Define severity levels
+[severity]
+error = ["unused-parameter", "exported", "var-naming"]
+warning = ["line-length"]
+
+# Enable and configure desired rules
+[rules]
+
+# Enforces comments on exported types/functions/consts
+[rules.exported]
+arguments = ["comment should start with the name of the object"]
+
+# Warn if function parameters are unused
+[rules.unused-parameter]
+
+# Warn if variable names are too short (1-letter vars not allowed)
+[rules.var-naming]
+arguments = ["min-length=2"]
+
+# Warn for long lines
+[rules.line-length]
+arguments = ["max-len=120"]

--- a/utify.go
+++ b/utify.go
@@ -1,3 +1,4 @@
+// Package utify provides styled terminal output with color, formatting, and behavior control.
 package utify
 
 import (
@@ -9,6 +10,7 @@ import (
 	"strings"
 )
 
+// ANSI color codes and styles for terminal output
 const (
 	ColorRed       = "\033[31m"
 	ColorGreen     = "\033[32m"
@@ -24,8 +26,10 @@ const (
 	StyleReset     = "\033[0m"
 )
 
+// MessageType defines supported message categories for terminal output.
 type MessageType string
 
+// Options defines configuration flags for how messages are styled and handled.
 type Options struct {
 	Bold     bool
 	Italic   bool
@@ -36,47 +40,57 @@ type Options struct {
 	Callback func(MessageType, string)
 }
 
+// OptionsDefault returns a new Options instance with default configuration.
 func OptionsDefault() *Options {
 	return &Options{}
 }
 
+// WithBold enables bold formatting for the message.
 func (o *Options) WithBold() *Options {
 	o.Bold = true
 	return o
 }
 
+// WithItalic enables italic formatting for the message.
 func (o *Options) WithItalic() *Options {
 	o.Italic = true
 	return o
 }
 
+// WithoutColor disables all color formatting for the message.
 func (o *Options) WithoutColor() *Options {
 	o.NoColor = true
 	return o
 }
 
+// WithoutIcon disables the icon (future-proof option).
 func (o *Options) WithoutIcon() *Options {
 	o.NoIcon = true
 	return o
 }
 
+// WithoutStyle disables bold and italic formatting.
 func (o *Options) WithoutStyle() *Options {
 	o.NoStyle = true
 	return o
 }
 
+// WithExit sets the option to exit the program after printing an error message.
 func (o *Options) WithExit() *Options {
 	o.Exit = true
 	o.Callback = nil
 	return o
 }
 
+// WithCallback sets a custom callback to run after the message is printed.
+// This disables automatic program exit.
 func (o *Options) WithCallback(cb func(MessageType, string)) *Options {
 	o.Callback = cb
 	o.Exit = false
 	return o
 }
 
+// MessageType constants represent predefined categories for terminal messages.
 const (
 	MessageSuccess    MessageType = "success"
 	MessageError      MessageType = "error"
@@ -106,6 +120,7 @@ const (
 	Default           MessageType = "default"
 )
 
+// colors maps each MessageType to its corresponding ANSI color.
 var colors = map[MessageType]string{
 	MessageSuccess:    ColorGreen,
 	MessageError:      ColorRed,
@@ -135,13 +150,13 @@ var colors = map[MessageType]string{
 	Default:           ColorWhite,
 }
 
+// ErrSilent is returned for errors that have already been displayed.
 var ErrSilent = errors.New("silent error")
+
 var userColors = map[string]string{}
 
-func SetColorTable(newColors map[string]string) {
-	maps.Copy(userColors, newColors)
-}
-
+// getColor returns the ANSI color for a given message type,
+// checking user overrides before falling back to defaults.
 func getColor(msgType MessageType) string {
 	if color, exists := userColors[string(msgType)]; exists {
 		return color
@@ -150,6 +165,13 @@ func getColor(msgType MessageType) string {
 	return colors[msgType]
 }
 
+// SetColorTable replaces or extends the internal color map.
+func SetColorTable(newColors map[string]string) {
+	maps.Copy(userColors, newColors)
+}
+
+// Echo renders a styled message of the given type and returns the raw message and an optional error.
+// If a callback is set in options, it will be executed. If Exit is true and the message is an error type, the program will exit.
 func Echo(msgType MessageType, text string, opts *Options) (string, error) {
 	color := getColor(msgType)
 
@@ -196,322 +218,354 @@ func Echo(msgType MessageType, text string, opts *Options) (string, error) {
 	return text, nil
 }
 
+// Success prints a green success message to the terminal.
 func Success(text string, opts *Options) {
 	_, _ = Echo(MessageSuccess, text, opts)
 }
 
+// Error prints a red error message to the terminal.
 func Error(text string, opts *Options) {
 	_, _ = Echo(MessageError, text, opts)
 }
 
+// Warning prints a yellow warning message to the terminal.
 func Warning(text string, opts *Options) {
 	_, _ = Echo(MessageWarning, text, opts)
 }
 
+// Info prints a cyan informational message to the terminal.
 func Info(text string, opts *Options) {
 	_, _ = Echo(MessageInfo, text, opts)
 }
 
+// Debug prints a gray debug message to the terminal.
 func Debug(text string, opts *Options) {
 	_, _ = Echo(MessageDebug, text, opts)
 }
 
+// Critical prints a magenta critical error message to the terminal.
 func Critical(text string, opts *Options) {
 	_, _ = Echo(MessageCritical, text, opts)
 }
 
+// Delete prints a red delete action message to the terminal.
 func Delete(text string, opts *Options) {
 	_, _ = Echo(MessageDelete, text, opts)
 }
 
+// Update prints a yellow update action message to the terminal.
 func Update(text string, opts *Options) {
 	_, _ = Echo(MessageUpdate, text, opts)
 }
 
+// Install prints a green install action message to the terminal.
 func Install(text string, opts *Options) {
 	_, _ = Echo(MessageInstall, text, opts)
 }
 
+// Upgrade prints a light blue upgrade action message to the terminal.
 func Upgrade(text string, opts *Options) {
 	_, _ = Echo(MessageUpgrade, text, opts)
 }
 
+// Edit prints a blue edit action message to the terminal.
 func Edit(text string, opts *Options) {
 	_, _ = Echo(MessageEdit, text, opts)
 }
 
+// New prints a green message for newly created items.
 func New(text string, opts *Options) {
 	_, _ = Echo(MessageNew, text, opts)
 }
 
+// Download prints a message related to downloads.
 func Download(text string, opts *Options) {
 	_, _ = Echo(MessageDownload, text, opts)
 }
 
+// Upload prints a message related to uploads.
 func Upload(text string, opts *Options) {
 	_, _ = Echo(MessageUpload, text, opts)
 }
 
+// Sync prints a message related to synchronization.
 func Sync(text string, opts *Options) {
 	_, _ = Echo(MessageSync, text, opts)
 }
 
+// Search prints a message related to search operations.
 func Search(text string, opts *Options) {
 	_, _ = Echo(MessageSearch, text, opts)
 }
 
+// Successf formats and prints a success message.
 func Successf(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Success(text, opts)
 }
 
+// Errorf formats and prints an error message.
 func Errorf(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Error(text, opts)
 }
 
+// Warningf formats and prints a warning message.
 func Warningf(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Warning(text, opts)
 }
 
+// Infof formats and prints an informational message.
 func Infof(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Info(text, opts)
 }
 
+// Debugf formats and prints a debug message.
 func Debugf(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Debug(text, opts)
 }
 
+// Criticalf formats and prints a critical error message.
 func Criticalf(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Critical(text, opts)
 }
 
+// Deletef formats and prints a delete message.
 func Deletef(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Delete(text, opts)
 }
 
+// Updatef formats and prints an update message.
 func Updatef(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Update(text, opts)
 }
 
+// Installf formats and prints an install message.
 func Installf(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Install(text, opts)
 }
 
+// Upgradef formats and prints an upgrade message.
 func Upgradef(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Upgrade(text, opts)
 }
 
+// Editf formats and prints an edit message.
 func Editf(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Edit(text, opts)
 }
 
+// Newf formats and prints a creation message.
 func Newf(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	New(text, opts)
 }
 
+// Downloadf formats and prints a download message.
 func Downloadf(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Download(text, opts)
 }
 
+// Uploadf formats and prints an upload message.
 func Uploadf(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Upload(text, opts)
 }
 
+// Syncf formats and prints a sync message.
 func Syncf(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Sync(text, opts)
 }
 
+// Searchf formats and prints a search message.
 func Searchf(text string, opts *Options, args ...any) {
 	text = fmt.Sprintf(text, args...)
-
 	Search(text, opts)
 }
 
+// GetSuccess returns a success message with optional error.
 func GetSuccess(text string, opts *Options) (string, error) {
 	return Echo(MessageSuccess, text, opts)
 }
 
+// GetError returns an error message with optional error.
 func GetError(text string, opts *Options) (string, error) {
 	return Echo(MessageError, text, opts)
 }
 
+// GetWarning returns a warning message with optional error.
 func GetWarning(text string, opts *Options) (string, error) {
 	return Echo(MessageWarning, text, opts)
 }
 
+// GetInfo returns an informational message with optional error.
 func GetInfo(text string, opts *Options) (string, error) {
 	return Echo(MessageInfo, text, opts)
 }
 
+// GetDebug returns a debug message with optional error.
 func GetDebug(text string, opts *Options) (string, error) {
 	return Echo(MessageDebug, text, opts)
 }
 
+// GetCritical returns a critical message with optional error.
 func GetCritical(text string, opts *Options) (string, error) {
 	return Echo(MessageCritical, text, opts)
 }
 
+// GetDelete returns a delete message with optional error.
 func GetDelete(text string, opts *Options) (string, error) {
 	return Echo(MessageDelete, text, opts)
 }
 
+// GetUpdate returns an update message with optional error.
 func GetUpdate(text string, opts *Options) (string, error) {
 	return Echo(MessageUpdate, text, opts)
 }
 
+// GetInstall returns an install message with optional error.
 func GetInstall(text string, opts *Options) (string, error) {
 	return Echo(MessageInstall, text, opts)
 }
 
+// GetUpgrade returns an upgrade message with optional error.
 func GetUpgrade(text string, opts *Options) (string, error) {
 	return Echo(MessageUpgrade, text, opts)
 }
 
+// GetEdit returns an edit message with optional error.
 func GetEdit(text string, opts *Options) (string, error) {
 	return Echo(MessageEdit, text, opts)
 }
 
+// GetNew returns a creation message with optional error.
 func GetNew(text string, opts *Options) (string, error) {
 	return Echo(MessageNew, text, opts)
 }
 
+// GetDownload returns a download message with optional error.
 func GetDownload(text string, opts *Options) (string, error) {
 	return Echo(MessageDownload, text, opts)
 }
 
+// GetUpload returns an upload message with optional error.
 func GetUpload(text string, opts *Options) (string, error) {
 	return Echo(MessageUpload, text, opts)
 }
 
+// GetSync returns a sync message with optional error.
 func GetSync(text string, opts *Options) (string, error) {
 	return Echo(MessageSync, text, opts)
 }
 
+// GetSearch returns a search message with optional error.
 func GetSearch(text string, opts *Options) (string, error) {
 	return Echo(MessageSearch, text, opts)
 }
 
+// GetSuccessf returns a formatted success message with optional error.
 func GetSuccessf(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetSuccess(text, opts)
 }
 
+// GetErrorf returns a formatted error message with optional error.
 func GetErrorf(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetError(text, opts)
 }
 
+// GetWarningf returns a formatted warning message with optional error.
 func GetWarningf(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetWarning(text, opts)
 }
 
+// GetInfof returns a formatted informational message with optional error.
 func GetInfof(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetInfo(text, opts)
 }
 
+// GetDebugf returns a formatted debug message with optional error.
 func GetDebugf(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetDebug(text, opts)
 }
 
+// GetCriticalf returns a formatted critical message with optional error.
 func GetCriticalf(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetCritical(text, opts)
 }
 
+// GetDeletef returns a formatted delete message with optional error.
 func GetDeletef(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetDelete(text, opts)
 }
 
+// GetUpdatef returns a formatted update message with optional error.
 func GetUpdatef(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetUpdate(text, opts)
 }
 
+// GetInstallf returns a formatted install message with optional error.
 func GetInstallf(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetInstall(text, opts)
 }
 
+// GetUpgradef returns a formatted upgrade message with optional error.
 func GetUpgradef(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetUpgrade(text, opts)
 }
 
+// GetEditf returns a formatted edit message with optional error.
 func GetEditf(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetEdit(text, opts)
 }
 
+// GetNewf returns a formatted creation message with optional error.
 func GetNewf(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetNew(text, opts)
 }
 
+// GetDownloadf returns a formatted download message with optional error.
 func GetDownloadf(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetDownload(text, opts)
 }
 
+// GetUploadf returns a formatted upload message with optional error.
 func GetUploadf(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetUpload(text, opts)
 }
 
+// GetSyncf returns a formatted sync message with optional error.
 func GetSyncf(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetSync(text, opts)
 }
 
+// GetSearchf returns a formatted search message with optional error.
 func GetSearchf(text string, opts *Options, args ...any) (string, error) {
 	text = fmt.Sprintf(text, args...)
-
 	return GetSearch(text, opts)
 }

--- a/utify_test.go
+++ b/utify_test.go
@@ -17,7 +17,7 @@ func captureOutput(f func()) string {
 
 	f()
 
-	w.Close()
+	_ = w.Close()
 	os.Stdout = old
 	_, _ = buf.ReadFrom(r)
 	return buf.String()
@@ -107,7 +107,7 @@ func TestExitDisablesCallback(t *testing.T) {
 
 func TestCallbackDisablesExit(t *testing.T) {
 	var called bool
-	cb := func(msgType MessageType, text string) {
+	cb := func(_ MessageType, _ string) {
 		called = true
 	}
 


### PR DESCRIPTION
This update restricts the CI workflow to trigger only on pull requests and semantic version tags.
Tests continue to run across ubuntu, macOS, and Windows environments. Redundant runs on push to branches were removed.

Also:
- Removed unnecessary test duplication (test + coverage)
- Optimized matrix usage
- Retained full coverage reporting via Codecov